### PR TITLE
Fix typo in network usage description

### DIFF
--- a/LLLM/LLLM/Info.plist
+++ b/LLLM/LLLM/Info.plist
@@ -7,7 +7,7 @@
 		<string>_http._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Allow to access LM Studio</string>
+        <string>Allow access to LM Studio</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>


### PR DESCRIPTION
## Summary
- correct grammar in LLLM Info.plist

## Testing
- `swift --version`
